### PR TITLE
Fix for factor() moved to Primes module in Julia 0.5.0

### DIFF
--- a/src/CLFFT.jl
+++ b/src/CLFFT.jl
@@ -1,5 +1,7 @@
 module CLFFT
 
+import Primes
+
 import OpenCL.cl
 
 include("api.jl")
@@ -95,7 +97,7 @@ function Plan{T<:clfftNumber}(::Type{T}, ctx::cl.Context, sz::Dims)
     radices = supported_radices()
     for i in 1:ndim
         s = sz[i]
-        fs = keys(factor(s))
+        fs = keys(Primes.factor(s))
         if fs ⊆ radices
             lengths[i] = s
             total_length *= s
@@ -148,7 +150,7 @@ function Plan{T<:clfftNumber}(::Type{T}, ctx::cl.Context,
     radices = supported_radices()
     for i in 1:ndim
         s = insize[i]
-        fs = keys(factor(s))
+        fs = keys(Primes.factor(s))
         if fs ⊆ radices
             lengths[i] = s
             total_length *= s


### PR DESCRIPTION
Under Julia 0.5.0 using the CLFFT.Plan function results in a load error:

```
ERROR: LoadError: factor(100,) has been moved to the package Primes.jl.
Run Pkg.add("Primes") to install Primes on Julia v0.5-
 in factor(::Int64, ::Vararg{Int64,N}) at ./deprecated.jl:210
 in CLFFT.Plan{T<:Union{Complex{Float32},Complex{Float64},Float32,Float64}}(::Type{Complex{Float32}}, ::OpenCL.cl.Context, ::Tuple{Int64}) at $HOME/.julia/v0.5/CLFFT/src/CLFFT.jl:98
 in include_from_node1(::String) at ./loading.jl:488
while loading $HOME/Projects/Julia/clfft_demo.jl, in expression starting on line 13
```

This PR fixes error by importing Primes module
